### PR TITLE
Fix circular import in mapis_requests

### DIFF
--- a/mapis.py
+++ b/mapis.py
@@ -36,50 +36,7 @@ import mapis_screenshots
 import mapis_cache
 import mapis_license_notices
 
-APIS = {
-    "ip_api": {
-        "name": "IP-API",
-        "key_needed": False,
-        "target_types": [ "address" ],
-    },
-
-    "shodan": {
-        "name": "Shodan",
-        "key_needed": True,
-        "target_types": [ "address" ],
-    },
-
-    "vt": {
-        "name": "VirusTotal",
-        "key_needed": True,
-        "target_types": [ "address", "hash" ],
-    },
-
-    "tc": {
-        "name": "ThreatCrowd",
-        "key_needed": False,
-        "target_types": [ "address", "hash" ],
-    },
-
-    "otx": {
-        "name": "AlienVault OTX",
-        "key_needed": False,
-        "target_types": [ "address", "hash" ],
-    }
-
-    #"xforce": {
-    #    "name": "XForce",
-    #    "key_needed": True,
-    #    "target_types": [ "address", "hash" ],
-    #},
-}
-
-# APIS but only for those with key_needed
-KEY_APIS = {
-    api: data
-        for api, data in APIS.items()
-        if data["key_needed"]
-}
+from mapis_requests import APIS, KEY_APIS
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Query multiple API endpoints for information about IP addresses or hashes.")

--- a/mapis_requests.py
+++ b/mapis_requests.py
@@ -22,7 +22,51 @@
 import requests
 import vt
 
-from mapis import KEY_APIS
+
+APIS = {
+    "ip_api": {
+        "name": "IP-API",
+        "key_needed": False,
+        "target_types": [ "address" ],
+    },
+
+    "shodan": {
+        "name": "Shodan",
+        "key_needed": True,
+        "target_types": [ "address" ],
+    },
+
+    "vt": {
+        "name": "VirusTotal",
+        "key_needed": True,
+        "target_types": [ "address", "hash" ],
+    },
+
+    "tc": {
+        "name": "ThreatCrowd",
+        "key_needed": False,
+        "target_types": [ "address", "hash" ],
+    },
+
+    "otx": {
+        "name": "AlienVault OTX",
+        "key_needed": False,
+        "target_types": [ "address", "hash" ],
+    }
+
+    #"xforce": {
+    #    "name": "XForce",
+    #    "key_needed": True,
+    #    "target_types": [ "address", "hash" ],
+    #},
+}
+
+# APIS but only for those with key_needed
+KEY_APIS = {
+    api: data
+        for api, data in APIS.items()
+        if data["key_needed"]
+}
 
 def dummy_response(content):
     response = requests.models.Response()


### PR DESCRIPTION
Only comes up when doing `import mapis`, which I had somehow never done before. Unsure about mixing `import A` with `from A import B` but it seems fine.