### PR TITLE
Fix unbound vt-client when not using VT API

### DIFF
--- a/mapis.py
+++ b/mapis.py
@@ -203,6 +203,8 @@ def main():
 
     if "vt" in args.api_list:
         vt_client = vt.Client(keys["vt"])
+    else:
+        vt_client = None
 
     previous_target = None
     previous_target_type = None


### PR DESCRIPTION
The lookup loop always passes `vt_client` into `mapis_requests.make_request()`, so we need to make sure that it is always instantiated